### PR TITLE
cleaner env set up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
       run: |
         mkdir powr/exe_dev.dir
         cp src/*.opt powr/exe_dev.dir/.
-        cp powr/powrconfig ~/.powrconfig
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,6 @@ doc/
 
 # testmodels
 testmodels/
+
+# modified .powrconfig
+powr/.powrconfig

--- a/powr/powrconfig
+++ b/powr/powrconfig
@@ -1,7 +1,7 @@
 # bash style for the PoWR scripts
 
 # define the powr work directory
-# export POWR_WORK=powr/
+export POWR_WORK=
 export POWR_INSTTYPE=local
 # export POWR_INSTTYPE=potsdam
 # export POWR_INSTTYPE=niscluster

--- a/powr/proc.dir/makechain.com
+++ b/powr/proc.dir/makechain.com
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# source ~/.powrconfig || exit
+source ~/.powrconfig || exit
 
 # this script generates a new chain for PoWR with number "kn" given via call
 # created by H. Todt 05.03.2008

--- a/powr/proc.dir/submit.com
+++ b/powr/proc.dir/submit.com
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# source ~/.powrconfig || exit
+source ~/.powrconfig || exit
 
 ####################################################################
 #

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -30,6 +30,8 @@ def inject_path(set_vars):
     powrconfig_file = set_vars / ".powrconfig"
     with open(powrconfig_file, "w") as f:
         f.write(powrconfig)
+    os.system("cp ${POWR_WORK}/.powrconfig ${HOME}/.powrconfig")
+    os.system("echo ${HOME}")
 
 
 @pytest.fixture(scope="session")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,54 @@
+import pytest
+import os
+import subprocess
+from pathlib import Path
+
+
+# get the path of this file and export variables accordingly
+@pytest.fixture(scope="session")
+def set_vars():
+    filedir = Path(__file__).parents[0]
+    powrdir = filedir.parents[0] / "powr"
+    os.environ["POWR_WORK"] = powrdir.as_posix()
+    os.environ["POWREXEPATH"] = (powrdir / "exe.dir").as_posix()
+    return powrdir
+
+
+@pytest.fixture(scope="session")
+def set_aliases(set_vars):
+    setup_file = "bash_setup"  # this could be different on MacOS
+    # the aliases setup currently does not work as the aliases
+    # are destryed between subprocess sessions
+    # either we set them in the python script or
+    # run explicitly with passing the env as dict
+    full_file_path = "${POWR_WORK}/proc.dir/" + setup_file
+    subprocess.run(
+        full_file_path,
+        shell=True,
+        check=True,
+        executable="/bin/bash",
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture(scope="session")
+def get_chain(set_aliases):
+    makechain_command = "${POWR_WORK}/proc.dir/makechain.com 1"
+    subprocess.run(
+        makechain_command,
+        shell=True,
+        check=True,
+        executable="/bin/bash",
+        capture_output=True,
+        text=True,
+    )
+    yield "Created chain 1"
+    # teardown directories
+    # we need access to ${POWR_WORK} so shutil will not work
+    # why does sourcing powrconfig in the script not work?
+    os.system("rm -rf ${POWR_WORK}/scratch")
+    os.system("rm -rf ${POWR_WORK}/output")
+    os.system("rm -rf ${POWR_WORK}/wrdata1")
+    os.system("rm -rf ${POWR_WORK}/wrjobs")
+    return "Cleaned working dirs"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -31,7 +31,6 @@ def inject_path(set_vars):
     with open(powrconfig_file, "w") as f:
         f.write(powrconfig)
     os.system("cp ${POWR_WORK}/.powrconfig ${HOME}/.powrconfig")
-    os.system("echo ${HOME}")
 
 
 @pytest.fixture(scope="session")

--- a/test/test_colitest.py
+++ b/test/test_colitest.py
@@ -1,6 +1,5 @@
 import os
 import subprocess
-from pathlib import Path
 import pytest
 import numpy as np
 
@@ -19,56 +18,6 @@ MODEL_DATA_REF = np.array(
         13.787069162858446,
     ]
 )
-
-
-# get the path of this file and export variables accordingly
-@pytest.fixture(scope="module")
-def set_vars():
-    filedir = Path(__file__).parents[0]
-    powrdir = filedir.parents[0] / "powr"
-    os.environ["POWR_WORK"] = powrdir.as_posix()
-    os.environ["POWREXEPATH"] = (powrdir / "exe.dir").as_posix()
-    return powrdir
-
-
-@pytest.fixture(scope="module")
-def set_aliases(set_vars):
-    setup_file = "bash_setup"  # this could be different on MacOS
-    # the aliases setup currently does not work as the aliases
-    # are destryed between subprocess sessions
-    # either we set them in the python script or
-    # run explicitly with passing the env as dict
-    full_file_path = "${POWR_WORK}/proc.dir/" + setup_file
-    subprocess.run(
-        full_file_path,
-        shell=True,
-        check=True,
-        executable="/bin/bash",
-        capture_output=True,
-        text=True,
-    )
-
-
-@pytest.fixture(scope="module")
-def get_chain(set_aliases):
-    makechain_command = "${POWR_WORK}/proc.dir/makechain.com 1"
-    subprocess.run(
-        makechain_command,
-        shell=True,
-        check=True,
-        executable="/bin/bash",
-        capture_output=True,
-        text=True,
-    )
-    yield "Created chain 1"
-    # teardown directories
-    # we need access to ${POWR_WORK} so shutil will not work
-    # why does sourcing powrconfig in the script not work?
-    os.system("rm -rf ${POWR_WORK}/scratch")
-    os.system("rm -rf ${POWR_WORK}/output")
-    os.system("rm -rf ${POWR_WORK}/wrdata1")
-    os.system("rm -rf ${POWR_WORK}/wrjobs")
-    return "Cleaned working dirs"
 
 
 @pytest.fixture(scope="module")

--- a/test/test_colitest.py
+++ b/test/test_colitest.py
@@ -38,6 +38,7 @@ def run_colitest(get_chain):
     os.system("cat ${POWR_WORK}/output/colitest1.cpr")
     yield "ran colitest"
     os.system("rm -rf ${POWR_WORK}/tmp_data")
+    os.system("rm -rf ${POWR_WORK}/tmp_2day/*")
     return "Cleaned colitest tmp data"
 
 
@@ -69,6 +70,8 @@ def test_makechain(set_vars, get_chain):
     wrdata1_content = [
         "CARDS",
         "DATOM",
+        "FEDAT",
+        "FEDAT_FORMAL",
         "FGRID",
         "FORMAL_CARDS",
         "MODEL",
@@ -136,5 +139,5 @@ def test_colitest_run(set_vars, run_colitest):
 def test_read_model(set_vars, run_colitest):
     model_output = set_vars / "wrdata1" / "MODEL_STUDY_DONE"
     data_np = np.fromfile(model_output, dtype=float)
-    assert len(data_np) == 2233856
+    assert len(data_np) == 2246784
     assert np.allclose(data_np[256138:256149], MODEL_DATA_REF)

--- a/test/test_wrstart.py
+++ b/test/test_wrstart.py
@@ -23,7 +23,6 @@ def run_wrstart(get_chain):
     os.system("ls ${POWR_WORK}/wrdata1")
     os.system("ls ${POWR_WORK}/output")
     os.system("cat ${POWR_WORK}/output/*.cpr")
-
     yield "ran powr full cycle"
     os.system("rm -rf ${POWR_WORK}/tmp_data")
     return "Cleaned powr tmp data"

--- a/test/test_wrstart.py
+++ b/test/test_wrstart.py
@@ -1,61 +1,8 @@
 import os
 import subprocess
-from pathlib import Path
 import pytest
+
 # import numpy as np
-
-
-# get the path of this file and export variables accordingly
-@pytest.fixture(scope="module")
-def set_vars():
-    filedir = Path(__file__).parents[0]
-    powrdir = filedir.parents[0] / "powr"
-    os.environ["POWR_WORK"] = powrdir.as_posix()
-    os.environ["POWREXEPATH"] = (powrdir / "exe.dir").as_posix()
-    print("powr work in set_vars")
-    os.system("echo ${POWR_WORK}")
-    return powrdir
-
-
-@pytest.fixture(scope="module")
-def set_aliases(set_vars):
-    setup_file = "bash_setup"  # this could be different on MacOS
-    # the aliases setup currently does not work as the aliases
-    # are destryed between subprocess sessions
-    # either we set them in the python script or
-    # run explicitly with passing the env as dict
-    full_file_path = "${POWR_WORK}/proc.dir/" + setup_file
-    subprocess.run(
-        full_file_path,
-        shell=True,
-        check=True,
-        executable="/bin/bash",
-        capture_output=True,
-        text=True,
-    )
-
-
-@pytest.fixture(scope="module")
-def get_chain(set_aliases):
-    makechain_command = "${POWR_WORK}/proc.dir/makechain.com 1"
-    subprocess.run(
-        makechain_command,
-        shell=True,
-        check=True,
-        executable="/bin/bash",
-        capture_output=True,
-        text=True,
-    )
-    os.system("ls ${POWR_WORK}")
-    yield "Created chain 1"
-    # teardown directories
-    # we need access to ${POWR_WORK} so shutil will not work
-    # why does sourcing powrconfig in the script not work?
-    os.system("rm -rf ${POWR_WORK}/scratch")
-    os.system("rm -rf ${POWR_WORK}/output")
-    os.system("rm -rf ${POWR_WORK}/wrdata1")
-    os.system("rm -rf ${POWR_WORK}/wrjobs")
-    return "Cleaned working dirs"
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
- move set-up and teardown to conftest
- improve initialization of the environment in pytest using the existing framework in bash